### PR TITLE
Added TestTypes.hs as an extra source file to Cabal build

### DIFF
--- a/genifunctors.cabal
+++ b/genifunctors.cabal
@@ -11,6 +11,7 @@ build-type:          Simple
 cabal-version:       >=1.10
 homepage:            https://github.com/danr/genifunctors
 bug-reports:         https://github.com/danr/genifunctors/issues
+extra-source-files:  TestTypes.hs
 
 source-repository head
   type: git


### PR DESCRIPTION
This way, the file will be included in source distributions generated
with `cabal sdist`.
