### PR TITLE
Trivial support for non-parametric types

### DIFF
--- a/Test.hs
+++ b/Test.hs
@@ -1,4 +1,10 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE TemplateHaskell #-}
+#if __GLASGOW_HASKELL__ >= 706
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GADTs #-}
+#endif
 module Main where
 
 import Data.Generics.Genifunctors
@@ -46,6 +52,26 @@ travVCustom = $(genTraverseT [(''U, 'travUCustom)] ''V)
 travW :: Applicative f => (a -> f a') -> (b -> f b') -> W a b -> f (W a' b')
 travW = $(genTraverse ''W)
 
+#if __GLASGOW_HASKELL__ >= 708
+fmapZ :: (a -> b) -> (c -> d) -> Z a i c -> Z b i d
+fmapZ = $(genFmap ''Z)
+ 
+foldZ :: (Monoid m) => (a -> m) -> (c -> m) -> Z a i c -> m
+foldZ = $(genFoldMap ''Z)
+
+travZ :: Applicative f => (a -> f b) -> (c -> f d) -> Z a i c -> f (Z b i d)
+travZ = $(genTraverse ''Z)
+
+fmapZU :: (a -> b) -> ZU f a -> ZU f b
+fmapZU = $(genFmap ''ZU)
+
+foldZU :: (Monoid m) => (a -> m) -> ZU f a -> m
+foldZU = $(genFoldMap ''ZU)
+
+travZU :: Applicative g => (a -> g b) -> ZU f a -> g (ZU f b)
+travZU = $(genTraverse ''ZU)
+#endif
+
 assertEq :: (Show a,Eq a) => a -> a -> IO ()
 assertEq a b | a == b = return ()
 assertEq a b = do
@@ -56,12 +82,20 @@ main :: IO ()
 main = do
     let v = L [0 :+: 1, M (X ((Right 5) :+: 4)), M (Z (2,3)), R 6 ""]
     assertEq (fmapU (+1) (+2) (+3) (+4) v) (L [1 :+: 1, M (X ((Right 9) :+: 4)), M (Z (3,5)), R 9 ""])
-    let s = (:[])
     assertEq (foldU s s s s v) ([0,5,2,3,6])
     assertEq (foldUCustom s s s s v) ([0,5,3,2,6])
-    let t = tell . s
     assertEq (execWriter (travU t t t t v)) ([0,5,2,3,6])
     assertEq (execWriter (travUCustom t t t t v)) ([0,5,3,2,6])
     assertEq (execWriter (travW t t (W 3))) [3]
-
+#if __GLASGOW_HASKELL__ >= 708
+    assertEq (execWriter (travZ t t (A2 (2,3)))) [2,3]
+    assertEq (execWriter (travZ t t (AB (ZT 1)))) [1]
+    assertEq (execWriter (travZ t t (AB (ZF "a")))) []
+    assertEq (execWriter (travZ t t (AS (A2 (1,1))))) [1,1]
+    assertEq (execWriter (travZU t  (ZU (Just 2) 1))) [1]
+    assertEq (execWriter (travZ t t (AN STrue [2,3,4,5]))) [2,3,4,5]
+#endif
+  where
+    s = (:[])
+    t = tell . s
 

--- a/TestTypes.hs
+++ b/TestTypes.hs
@@ -1,7 +1,11 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE KindSignatures #-}
-#if __GLASGOW_HASKELL >= 704
+{-# LANGUAGE RankNTypes #-}
+#if __GLASGOW_HASKELL__ >= 708
 {-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE TypeFamilies #-}
 #endif
 module TestTypes where
 
@@ -17,3 +21,27 @@ data V u v = X (U v v u u) | Z u
 
 data W (a :: *) b = W b
  deriving (Eq,Show)
+
+#if __GLASGOW_HASKELL__ >= 708
+data family Sing (a :: k)
+data instance Sing (a :: Bool) where
+    SFalse :: Sing False
+    STrue  :: Sing True
+
+data ZB a b (τ :: Bool) where
+  ZT :: a -> ZB a b True
+  ZF :: b -> ZB a b False
+  ZR :: ZB a b τ -> ZB a b τ
+
+data Z a (τ :: Bool) b where
+  A1 :: a       -> Z a False b
+  A2 :: (a,a)   -> Z a True  b 
+  A3 :: b       -> Z a False b
+  AB :: ZB a String τ -> Z b τ a
+  AN :: Sing τ -> [a] -> Z a τ c
+  AS :: Z a True b -> Z a True b
+  AF :: Z a True x -> Z a True b
+
+data ZU f a where
+  ZU :: f Int -> a -> ZU f a
+#endif

--- a/genifunctors.cabal
+++ b/genifunctors.cabal
@@ -28,6 +28,7 @@ library
 
 test-suite test
     type:                exitcode-stdio-1.0
+--    ghc-options:         -ddump-splices
     main-is:             Test.hs
     build-depends:       base, template-haskell < 3, mtl, containers
     default-language:    Haskell2010


### PR DESCRIPTION
Non-plain type variables will be silently ignored.

Type family instantiations within type constructors will be ignored, as
long as they don't involve any of the plain variables.
